### PR TITLE
Escape single quote (') characters as &#39;

### DIFF
--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -285,12 +285,11 @@ line1 = second drop1 . break (== '\n')
 
 -- | Escape a string such that it can be inserted into an HTML document or @\"@ attribute
 --   without any special interpretation. This requires escaping the @<@, @>@, @&@ and @\"@ characters.
---   Note that it does /not/ escape @\'@, so will not work when placed in a @\'@ delimited attribute.
---   Also note that it will escape @\"@ even though that is not required in an HTML body (but is not harmful).
+--   Note that it will escape @\"@ and @\'@ even though that is not required in an HTML body (but is not harmful).
 --
 -- > escapeHTML "this is a test" == "this is a test"
 -- > escapeHTML "<b>\"g&t\"</n>" == "&lt;b&gt;&quot;g&amp;t&quot;&lt;/n&gt;"
--- > escapeHTML "don't" == "don't"
+-- > escapeHTML "t'was another test" == "t&#39;was another test"
 escapeHTML :: String -> String
 escapeHTML = concatMap f
     where
@@ -298,6 +297,7 @@ escapeHTML = concatMap f
         f '<' = "&lt;"
         f '&' = "&amp;"
         f '\"' = "&quot;"
+        f '\'' = "&#39;"
         f x = [x]
 
 -- | Invert of 'escapeHTML' (does not do general HTML unescaping)
@@ -309,6 +309,7 @@ unescapeHTML ('&':xs)
     | Just xs <- stripPrefix "gt;" xs = '>' : unescapeHTML xs
     | Just xs <- stripPrefix "amp;" xs = '&' : unescapeHTML xs
     | Just xs <- stripPrefix "quot;" xs = '\"' : unescapeHTML xs
+    | Just xs <- stripPrefix "#39;" xs = '\'' : unescapeHTML xs
 unescapeHTML (x:xs) = x : unescapeHTML xs
 unescapeHTML [] = []
 

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -142,7 +142,7 @@ tests = do
     testGen "line1 \"test\\nrest\\nmore\" == (\"test\",\"rest\\nmore\")" $ line1 "test\nrest\nmore" == ("test","rest\nmore")
     testGen "escapeHTML \"this is a test\" == \"this is a test\"" $ escapeHTML "this is a test" == "this is a test"
     testGen "escapeHTML \"<b>\\\"g&t\\\"</n>\" == \"&lt;b&gt;&quot;g&amp;t&quot;&lt;/n&gt;\"" $ escapeHTML "<b>\"g&t\"</n>" == "&lt;b&gt;&quot;g&amp;t&quot;&lt;/n&gt;"
-    testGen "escapeHTML \"don't\" == \"don't\"" $ escapeHTML "don't" == "don't"
+    testGen "escapeHTML \"t'was another test\" == \"t&#39;was another test\"" $ escapeHTML "t'was another test" == "t&#39;was another test"
     testGen "\\xs -> unescapeHTML (escapeHTML xs) == xs" $ \xs -> unescapeHTML (escapeHTML xs) == xs
     testGen "escapeJSON \"this is a test\" == \"this is a test\"" $ escapeJSON "this is a test" == "this is a test"
     testGen "escapeJSON \"\\ttab\\nnewline\\\\\" == \"\\\\ttab\\\\nnewline\\\\\\\\\"" $ escapeJSON "\ttab\nnewline\\" == "\\ttab\\nnewline\\\\"


### PR DESCRIPTION
This corresponds to a similar fix for `tagsoup` (see ndmitchell/tagsoup#74).