### PR TITLE
Generalised anyM, allM, orM, andM, findM, firstJustM to Foldables whi…

### DIFF
--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -202,9 +202,9 @@ notM = fmap not
 -- > anyM Just (Just True) == Just True
 -- > anyM Just Nothing == Just False
 #if __GLASGOW_HASKELL__ < 710
-anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
-#else
 anyM :: (Foldable f, Functor m, Monad m) => (a -> m Bool) -> f a -> m Bool
+#else
+anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
 #endif
 anyM p = fmap isJust . findM p
 
@@ -216,9 +216,9 @@ anyM p = fmap isJust . findM p
 -- > allM Just (Just False) == Just False
 -- > allM Just Nothing == Just True
 #if __GLASGOW_HASKELL__ < 710
-allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
-#else
 allM :: (Foldable f, Functor m, Monad m) => (a -> m Bool) -> f a -> m Bool
+#else
+allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
 #endif
 allM p = notM . anyM (notM . p)
 
@@ -230,7 +230,11 @@ allM p = notM . anyM (notM . p)
 -- > orM (Just $ Just False) == Just False
 -- > orM (Just Nothing) == Nothing
 -- > orM Nothing == Just False
+#if __GLASGOW_HASKELL__ < 710
+orM :: (Foldable f, Functor m, Monad m) => f (m Bool) -> m Bool
+#else
 orM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
+#endif
 orM = anyM id
 
 -- | A version of 'and' lifted to a monad. Retains the short-circuiting behaviour.
@@ -241,7 +245,11 @@ orM = anyM id
 -- > andM (Just $ Just False) == Just False
 -- > andM (Just Nothing) == Nothing
 -- > andM Nothing == Just True
+#if __GLASGOW_HASKELL__ < 710
+andM :: (Foldable f, Functor m, Monad m) => f (m Bool) -> m Bool
+#else
 andM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
+#endif
 andM = allM id
 
 -- Searching

--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds, CPP #-}
 
 -- | Extra functions for "Control.Monad".
 --   These functions provide looping, list operations and booleans.
@@ -201,7 +201,11 @@ notM = fmap not
 -- > \(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)
 -- > anyM Just (Just True) == Just True
 -- > anyM Just Nothing == Just False
+#if __GLASGOW_HASKELL__ < 710
 anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+#else
+anyM :: (Foldable f, Functor m, Monad m) => (a -> m Bool) -> f a -> m Bool
+#endif
 anyM p = fmap isJust . findM p
 
 -- | A version of 'all' lifted to a monad. Retains the short-circuiting behaviour.
@@ -211,8 +215,12 @@ anyM p = fmap isJust . findM p
 -- > \(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)
 -- > allM Just (Just False) == Just False
 -- > allM Just Nothing == Just True
+#if __GLASGOW_HASKELL__ < 710
 allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
-allM p = fmap not . anyM (fmap not . p)
+#else
+allM :: (Foldable f, Functor m, Monad m) => (a -> m Bool) -> f a -> m Bool
+#endif
+allM p = notM . anyM (notM . p)
 
 -- | A version of 'or' lifted to a monad. Retains the short-circuiting behaviour.
 --

--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -25,7 +25,7 @@ import Data.Maybe
 import Data.Foldable
 import Control.Applicative
 import Data.Monoid
-import Prelude
+import Prelude hiding (foldr)
 
 -- General utilities
 

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -42,18 +42,34 @@ tests = do
     testGen "anyM Just [False,True ,undefined] == Just True" $ anyM Just [False,True ,undefined] == Just True
     testGen "anyM Just [False,False,undefined] == undefined" $ erroneous $ anyM Just [False,False,undefined]
     testGen "\\(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)" $ \(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)
+    testGen "anyM Just (Just True) == Just True" $ anyM Just (Just True) == Just True
+    testGen "anyM Just Nothing == Just False" $ anyM Just Nothing == Just False
     testGen "allM Just [True,False,undefined] == Just False" $ allM Just [True,False,undefined] == Just False
     testGen "allM Just [True,True ,undefined] == undefined" $ erroneous $ allM Just [True,True ,undefined]
     testGen "\\(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)" $ \(f :: Int -> Maybe Bool) xs -> anyM f xs == orM (map f xs)
+    testGen "allM Just (Just False) == Just False" $ allM Just (Just False) == Just False
+    testGen "allM Just Nothing == Just True" $ allM Just Nothing == Just True
     testGen "orM [Just False,Just True ,undefined] == Just True" $ orM [Just False,Just True ,undefined] == Just True
     testGen "orM [Just False,Just False,undefined] == undefined" $ erroneous $ orM [Just False,Just False,undefined]
     testGen "\\xs -> Just (or xs) == orM (map Just xs)" $ \xs -> Just (or xs) == orM (map Just xs)
+    testGen "orM (Just $ Just False) == Just False" $ orM (Just $ Just False) == Just False
+    testGen "orM (Just Nothing) == Nothing" $ orM (Just Nothing) == Nothing
+    testGen "orM Nothing == Just False" $ orM Nothing == Just False
     testGen "andM [Just True,Just False,undefined] == Just False" $ andM [Just True,Just False,undefined] == Just False
     testGen "andM [Just True,Just True ,undefined] == undefined" $ erroneous $ andM [Just True,Just True ,undefined]
     testGen "\\xs -> Just (and xs) == andM (map Just xs)" $ \xs -> Just (and xs) == andM (map Just xs)
+    testGen "andM (Just $ Just False) == Just False" $ andM (Just $ Just False) == Just False
+    testGen "andM (Just Nothing) == Nothing" $ andM (Just Nothing) == Nothing
+    testGen "andM Nothing == Just True" $ andM Nothing == Just True
     testGen "findM (Just . isUpper) \"teST\"             == Just (Just 'S')" $ findM (Just . isUpper) "teST"             == Just (Just 'S')
     testGen "findM (Just . isUpper) \"test\"             == Just Nothing" $ findM (Just . isUpper) "test"             == Just Nothing
     testGen "findM (Just . const True) [\"x\",undefined] == Just (Just \"x\")" $ findM (Just . const True) ["x",undefined] == Just (Just "x")
+    testGen "findM (Just . isUpper) (Just 'A') == Just (Just 'A')" $ findM (Just . isUpper) (Just 'A') == Just (Just 'A')
+    testGen "findM (Just . isUpper) Nothing == Just Nothing" $ findM (Just . isUpper) Nothing == Just Nothing
+    testGen "firstJustM (Just . fmap not) [Just True, Nothing] == Just (Just False)" $ firstJustM (Just . fmap not) [Just True, Nothing] == Just (Just False)
+    testGen "firstJustM (Just . fmap not) [Just False] == Just (Just True)" $ firstJustM (Just . fmap not) [Just False] == Just (Just True)
+    testGen "firstJustM (Just . fmap not) (Just $ Just False) == Just (Just True)" $ firstJustM (Just . fmap not) (Just $ Just False) == Just (Just True)
+    testGen "firstJustM (Just . fmap not) Nothing == Just Nothing" $ firstJustM (Just . fmap not) Nothing == Just Nothing
     testGen "fromLeft 1 (Left 3) == 3" $ fromLeft 1 (Left 3) == 3
     testGen "fromLeft 1 (Right \"foo\") == 1" $ fromLeft 1 (Right "foo") == 1
     testGen "fromRight 1 (Right 3) == 3" $ fromRight 1 (Right 3) == 3


### PR DESCRIPTION
Writing `allM f (S.toList s)` gets old after a while :)

The short-circuiting behaviour is preserved in `findM`, so it's preserved in the functions that have been rewritten to use it.

`findM` could've been rewritten to use `firstJustM`, but then we'd have the overhead of comparing boxed up `Just Bool`s instead of `Bool`s - there was already some duplication in the code so I figured it's probably not worth it.