### PR TITLE
Add Data.List.NonEmpty.Extra

### DIFF
--- a/extra.cabal
+++ b/extra.cabal
@@ -50,6 +50,7 @@ library
         Data.Either.Extra
         Data.IORef.Extra
         Data.List.Extra
+        Data.List.NonEmpty.Extra
         Data.Tuple.Extra
         Data.Typeable.Extra
         Data.Version.Extra

--- a/extra.cabal
+++ b/extra.cabal
@@ -36,7 +36,7 @@ library
         filepath,
         process,
         clock >= 0.7,
-        semigroups,
+        semigroups,  -- For GHC 7.10 since Data.List.NonEmpty wasn't in base then
         time
     if !os(windows)
         build-depends: unix

--- a/extra.cabal
+++ b/extra.cabal
@@ -36,6 +36,7 @@ library
         filepath,
         process,
         clock >= 0.7,
+        semigroups,
         time
     if !os(windows)
         build-depends: unix

--- a/extra.cabal
+++ b/extra.cabal
@@ -36,7 +36,8 @@ library
         filepath,
         process,
         clock >= 0.7,
-        semigroups,  -- For GHC 7.10 since Data.List.NonEmpty wasn't in base then
+        -- For GHC 7.10 since Data.List.NonEmpty wasn't in base then
+        semigroups,
         time
     if !os(windows)
         build-depends: unix

--- a/src/Data/List/NonEmpty/Extra.hs
+++ b/src/Data/List/NonEmpty/Extra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 -- | Extra functions for working with 'NonEmpty' lists. The package
 --   also exports the existing "Data.List.NonEmpty" functions.
@@ -8,6 +9,10 @@ module Data.List.NonEmpty.Extra(
     ) where
 
 import Data.List.NonEmpty
+
+#if __GLASGOW_HASKELL__ <= 802
+import Data.Semigroup ((<>))
+#endif
 
 infixl 5 |>, |:
 

--- a/src/Data/List/NonEmpty/Extra.hs
+++ b/src/Data/List/NonEmpty/Extra.hs
@@ -29,12 +29,12 @@ snoc = (|>)
 
 -- | Append a list to a non-empty list.
 --
--- > appendl (1 :| [2,3]) [4,5] = 1 :| [2,3,4,5]
+-- > appendl (1 :| [2,3]) [4,5] == 1 :| [2,3,4,5]
 appendl :: NonEmpty a -> [a] -> NonEmpty a
 appendl (x :| xs) l = x :| (xs ++ l)
 
 -- | Append a non-empty list to a list.
 --
--- > appendr [1,2,3] (4 :| [5]) = 1 :| [2,3,4,5]
+-- > appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]
 appendr :: [a] -> NonEmpty a -> NonEmpty a
 appendr l nel = foldr cons nel l

--- a/src/Data/List/NonEmpty/Extra.hs
+++ b/src/Data/List/NonEmpty/Extra.hs
@@ -1,0 +1,40 @@
+
+-- | Extra functions for working with 'NonEmpty' lists. The package
+--   also exports the existing "Data.List.NonEmpty" functions.
+module Data.List.NonEmpty.Extra(
+    module Data.List.NonEmpty,
+    (|:), (|>), snoc,
+    appendl, appendr
+    ) where
+
+import Data.List.NonEmpty
+
+infixl 5 |>, |:
+
+-- | /O(n)/. Append an element to a non-empty list.
+--
+-- > (1 :| [2,3]) |> 4 |> 5 == 1 :| [2,3,4,5]
+(|>) :: NonEmpty a -> a -> NonEmpty a
+(|>) xs x = xs <> pure x
+
+-- | Synonym for '|>'.
+snoc :: NonEmpty a -> a -> NonEmpty a
+snoc = (|>)
+
+-- | /O(n)/. Append an element to a list.
+--
+-- > [1,2,3] |: 4 |> 5 == 1 :| [2,3,4,5]
+(|:) :: [a] -> a -> NonEmpty a
+(|:) xs x = foldr cons (pure x) xs
+
+-- | Append a list to a non-empty list.
+--
+-- > appendl (1 :| [2,3]) [4,5] = 1 :| [2,3,4,5]
+appendl :: NonEmpty a -> [a] -> NonEmpty a
+appendl (x :| xs) l = x :| (xs ++ l)
+
+-- | Append a non-empty list to a list.
+--
+-- > appendr [1,2,3] (4 :| [5]) = 1 :| [2,3,4,5]
+appendr :: [a] -> NonEmpty a -> NonEmpty a
+appendr l nel = foldr cons nel l

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -24,6 +24,9 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     -- * Data.List.Extra
     -- | Extra functions available in @"Data.List.Extra"@.
     lower, upper, trim, trimStart, trimEnd, word1, line1, escapeHTML, escapeJSON, unescapeHTML, unescapeJSON, dropEnd, takeEnd, splitAtEnd, breakEnd, spanEnd, dropWhileEnd', takeWhileEnd, stripSuffix, stripInfix, stripInfixEnd, dropPrefix, dropSuffix, wordsBy, linesBy, breakOn, breakOnEnd, splitOn, split, chunksOf, notNull, list, unsnoc, cons, snoc, drop1, mconcatMap, groupSort, groupSortOn, groupSortBy, nubOrd, nubOrdBy, nubOrdOn, nubOn, groupOn, nubSort, nubSortBy, nubSortOn, maximumOn, minimumOn, disjoint, allSame, anySame, repeatedly, for, firstJust, concatUnzip, concatUnzip3, zipFrom, zipWithFrom, replace, merge, mergeBy,
+    -- * Data.List.NonEmpty.Extra
+    -- | Extra functions available in @"Data.List.NonEmpty.Extra"@.
+    (|:), (|>), appendl, appendr,
     -- * Data.Tuple.Extra
     -- | Extra functions available in @"Data.Tuple.Extra"@.
     first, second, (***), (&&&), dupe, both, fst3, snd3, thd3, curry3, uncurry3,
@@ -56,6 +59,7 @@ import Control.Monad.Extra
 import Data.Either.Extra
 import Data.IORef.Extra
 import Data.List.Extra
+import Data.List.NonEmpty.Extra hiding (cons, snoc)
 import Data.Tuple.Extra
 import Data.Version.Extra
 import Numeric.Extra

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -223,6 +223,10 @@ tests = do
     testGen "\\xs -> nubOrd xs == nub xs" $ \xs -> nubOrd xs == nub xs
     testGen "nubOrdOn length [\"a\",\"test\",\"of\",\"this\"] == [\"a\",\"test\",\"of\"]" $ nubOrdOn length ["a","test","of","this"] == ["a","test","of"]
     testGen "nubOrdBy (compare `on` length) [\"a\",\"test\",\"of\",\"this\"] == [\"a\",\"test\",\"of\"]" $ nubOrdBy (compare `on` length) ["a","test","of","this"] == ["a","test","of"]
+    testGen "(1 :| [2,3]) |> 4 |> 5 == 1 :| [2,3,4,5]" $ (1 :| [2,3]) |> 4 |> 5 == 1 :| [2,3,4,5]
+    testGen "[1,2,3] |: 4 |> 5 == 1 :| [2,3,4,5]" $ [1,2,3] |: 4 |> 5 == 1 :| [2,3,4,5]
+    testGen "appendl (1 :| [2,3]) [4,5] == 1 :| [2,3,4,5]" $ appendl (1 :| [2,3]) [4,5] == 1 :| [2,3,4,5]
+    testGen "appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]" $ appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]
     testGen "first succ (1,\"test\") == (2,\"test\")" $ first succ (1,"test") == (2,"test")
     testGen "second reverse (1,\"test\") == (1,\"tset\")" $ second reverse (1,"test") == (1,"tset")
     testGen "(succ *** reverse) (1,\"test\") == (2,\"tset\")" $ (succ *** reverse) (1,"test") == (2,"tset")

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -23,6 +23,7 @@ import Data.Either.Extra as X
 import Data.Function as X
 import Data.IORef.Extra as X
 import Data.List.Extra as X
+import Data.List.NonEmpty.Extra as X (NonEmpty(..), (|>), (|:), appendl, appendr)
 import Data.Monoid as X
 import Data.Tuple.Extra as X
 import Data.Typeable.Extra as X


### PR DESCRIPTION
Closes #44 

There's a problem with generating `Extra.hs`, since there are name clashes between `Data.List.NonEmpty` and `Data.List.Extra`, such as `cons`. Is there an easy workaround? Maybe remove it?