### PR TITLE
Add a few functions to Data.List.NonEmpty.Extra

### DIFF
--- a/Generate.hs
+++ b/Generate.hs
@@ -67,7 +67,7 @@ writeFileBinaryChanged file x = do
         writeFileBinary file x
 
 hidden :: String -> [String]
-hidden "Data.List.NonEmpty.Extra" = ["cons", "snoc"]
+hidden "Data.List.NonEmpty.Extra" = ["cons", "snoc", "sortOn", "union", "unionBy"]
 hidden _ = []
 
 notHidden :: String -> String -> Bool

--- a/src/Data/List/NonEmpty/Extra.hs
+++ b/src/Data/List/NonEmpty/Extra.hs
@@ -5,10 +5,14 @@
 module Data.List.NonEmpty.Extra(
     module Data.List.NonEmpty,
     (|:), (|>), snoc,
-    appendl, appendr
+    appendl, appendr,
+    sortOn, union, unionBy,
+    maximum1, minimum1, maximumBy1, minimumBy1, maximumOn1, minimumOn1
     ) where
 
-import Data.List.NonEmpty
+import           Data.Function
+import qualified Data.List as List
+import           Data.List.NonEmpty
 
 #if __GLASGOW_HASKELL__ <= 802
 import Data.Semigroup ((<>))
@@ -43,3 +47,47 @@ appendl (x :| xs) l = x :| (xs ++ l)
 -- > appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]
 appendr :: [a] -> NonEmpty a -> NonEmpty a
 appendr l nel = foldr cons nel l
+
+-- | Sort by comparing the results of a function applied to each element.
+--   The sort is stable, and the function is evaluated only once for
+--   each element.
+sortOn :: Ord b => (a -> b) -> NonEmpty a -> NonEmpty a
+sortOn f = fromList . List.sortOn f . toList
+
+-- | Return the union of two non-empty lists. Duplicates, and elements of the
+--   first list, are removed from the the second list, but if the first list
+--   contains duplicates, so will the result.
+--
+-- > (1 :| [3, 5, 3]) `union` (4 :| [5, 3, 5, 2]) == 1 :| [3, 5, 3, 4, 2]
+union :: Eq a => NonEmpty a -> NonEmpty a -> NonEmpty a
+union = unionBy (==)
+
+-- | The non-overloaded version of 'union'.
+unionBy :: (a -> a -> Bool) -> NonEmpty a -> NonEmpty a -> NonEmpty a
+unionBy eq xs ys = fromList $ List.unionBy eq (toList xs) (toList ys)
+
+-- | The largest element of a non-empty list.
+maximum1 :: Ord a => NonEmpty a -> a
+maximum1 = List.maximum
+
+-- | The least element of a non-empty list.
+minimum1 :: Ord a => NonEmpty a -> a
+minimum1 = List.minimum
+
+-- | The largest element of a non-empty list with respect to the given
+--   comparison function.
+maximumBy1 :: (a -> a -> Ordering) -> NonEmpty a -> a
+maximumBy1 = List.maximumBy
+
+-- | The least element of a non-empty list with respect to the given
+--   comparison function.
+minimumBy1 :: (a -> a -> Ordering) -> NonEmpty a -> a
+minimumBy1 = List.minimumBy
+
+-- | A version of 'maximum1' where the comparison is done on some extracted value.
+maximumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
+maximumOn1 f = maximumBy1 (compare `on` f)
+
+-- | A version of 'minimum1' where the comparison is done on some extracted value.
+minimumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
+minimumOn1 f = minimumBy1 (compare `on` f)

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -26,7 +26,7 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     lower, upper, trim, trimStart, trimEnd, word1, line1, escapeHTML, escapeJSON, unescapeHTML, unescapeJSON, dropEnd, takeEnd, splitAtEnd, breakEnd, spanEnd, dropWhileEnd', takeWhileEnd, stripSuffix, stripInfix, stripInfixEnd, dropPrefix, dropSuffix, wordsBy, linesBy, breakOn, breakOnEnd, splitOn, split, chunksOf, notNull, list, unsnoc, cons, snoc, drop1, mconcatMap, groupSort, groupSortOn, groupSortBy, nubOrd, nubOrdBy, nubOrdOn, nubOn, groupOn, nubSort, nubSortBy, nubSortOn, maximumOn, minimumOn, disjoint, allSame, anySame, repeatedly, for, firstJust, concatUnzip, concatUnzip3, zipFrom, zipWithFrom, replace, merge, mergeBy,
     -- * Data.List.NonEmpty.Extra
     -- | Extra functions available in @"Data.List.NonEmpty.Extra"@.
-    (|:), (|>), appendl, appendr,
+    (|:), (|>), appendl, appendr, maximum1, minimum1, maximumBy1, minimumBy1, maximumOn1, minimumOn1,
     -- * Data.Tuple.Extra
     -- | Extra functions available in @"Data.Tuple.Extra"@.
     first, second, (***), (&&&), dupe, both, fst3, snd3, thd3, curry3, uncurry3,
@@ -59,7 +59,7 @@ import Control.Monad.Extra
 import Data.Either.Extra
 import Data.IORef.Extra
 import Data.List.Extra
-import Data.List.NonEmpty.Extra hiding (cons, snoc)
+import Data.List.NonEmpty.Extra hiding (cons, snoc, sortOn, union, unionBy)
 import Data.Tuple.Extra
 import Data.Version.Extra
 import Numeric.Extra

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -227,6 +227,7 @@ tests = do
     testGen "[1,2,3] |: 4 |> 5 == 1 :| [2,3,4,5]" $ [1,2,3] |: 4 |> 5 == 1 :| [2,3,4,5]
     testGen "appendl (1 :| [2,3]) [4,5] == 1 :| [2,3,4,5]" $ appendl (1 :| [2,3]) [4,5] == 1 :| [2,3,4,5]
     testGen "appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]" $ appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]
+    testGen "(1 :| [3, 5, 3]) `union` (4 :| [5, 3, 5, 2]) == 1 :| [3, 5, 3, 4, 2]" $ (1 :| [3, 5, 3]) `union` (4 :| [5, 3, 5, 2]) == 1 :| [3, 5, 3, 4, 2]
     testGen "first succ (1,\"test\") == (2,\"test\")" $ first succ (1,"test") == (2,"test")
     testGen "second reverse (1,\"test\") == (1,\"tset\")" $ second reverse (1,"test") == (1,"tset")
     testGen "(succ *** reverse) (1,\"test\") == (2,\"tset\")" $ (succ *** reverse) (1,"test") == (2,"tset")

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -22,8 +22,8 @@ import Data.Char as X
 import Data.Either.Extra as X
 import Data.Function as X
 import Data.IORef.Extra as X
-import Data.List.Extra as X
-import Data.List.NonEmpty.Extra as X (NonEmpty(..), (|>), (|:), appendl, appendr)
+import Data.List.Extra as X hiding (union, unionBy)
+import Data.List.NonEmpty.Extra as X (NonEmpty(..), (|>), (|:), appendl, appendr, union, unionBy)
 import Data.Monoid as X
 import Data.Tuple.Extra as X
 import Data.Typeable.Extra as X


### PR DESCRIPTION
`sortOn`, `union` and `unionBy` are useful since they produce non-empty lists, so if one converts the input to regular lists and uses `Data.List`'s version, the output needs to be converted back to non-empty lists using the partial `fromList` function.

The minimum and maximum functions are the same as `Data.Foldable`'s version but are total, and thus may be preferred by some.