### PR TITLE
Add headDef, lastDef, and dropEnd1

### DIFF
--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -116,6 +116,7 @@ headDef _ (x:_) = x
 -- > \x xs -> lastDef x xs == last (x:xs)
 lastDef :: a -> [a] -> a
 lastDef d xs = foldl (\_ x -> x) d xs -- I know this looks weird, but apparently this is the fastest way to do this: https://hackage.haskell.org/package/base-4.12.0.0/docs/src/GHC.List.html#last
+{-# INLINE lastDef #-}
 
 
 -- | A composition of 'not' and 'null'.

--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -18,7 +18,8 @@ module Data.List.Extra(
     wordsBy, linesBy,
     breakOn, breakOnEnd, splitOn, split, chunksOf,
     -- * Basics
-    notNull, list, unsnoc, cons, snoc, drop1, mconcatMap,
+    headDef, lastDef, notNull, list, unsnoc, cons, snoc,
+    drop1, dropEnd1, mconcatMap,
     -- * Enum operations
     enumerate,
     -- * List operations
@@ -96,6 +97,25 @@ anySame = f []
 allSame :: Eq a => [a] -> Bool
 allSame [] = True
 allSame (x:xs) = all (x ==) xs
+
+
+-- | A total 'head' with a default value.
+--
+-- > headDef 1 []      == 1
+-- > headDef 1 [2,3,4] == 2
+-- > \x xs -> headDef x xs == fromMaybe x (listToMaybe xs)
+headDef :: a -> [a] -> a
+headDef d [] = d
+headDef _ (x:_) = x
+
+
+-- | A total 'last' with a default value.
+--
+-- > lastDef 1 []      == 1
+-- > lastDef 1 [2,3,4] == 4
+-- > \x xs -> lastDef x xs == last (x:xs)
+lastDef :: a -> [a] -> a
+lastDef d xs = foldl (\_ x -> x) d xs -- I know this looks weird, but apparently this is the fastest way to do this: https://hackage.haskell.org/package/base-4.12.0.0/docs/src/GHC.List.html#last
 
 
 -- | A composition of 'not' and 'null'.
@@ -508,6 +528,16 @@ firstJust f = listToMaybe . mapMaybe f
 drop1 :: [a] -> [a]
 drop1 [] = []
 drop1 (x:xs) = xs
+
+
+-- | Equivalent to @dropEnd 1@, but likely to be faster and a single lexeme.
+--
+-- > dropEnd1 ""         == ""
+-- > dropEnd1 "test"     == "tes"
+-- > \xs -> dropEnd 1 xs == dropEnd1 xs
+dropEnd1 :: [a] -> [a]
+dropEnd1 [] = []
+dropEnd1 (x:xs) = foldr (\z f y -> y : f z) (const []) xs x
 
 
 -- | Version on `concatMap` generalised to a `Monoid` rather than just a list.

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -23,7 +23,7 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     writeIORef', atomicWriteIORef', atomicModifyIORef_, atomicModifyIORef'_,
     -- * Data.List.Extra
     -- | Extra functions available in @"Data.List.Extra"@.
-    lower, upper, trim, trimStart, trimEnd, word1, line1, escapeHTML, escapeJSON, unescapeHTML, unescapeJSON, dropEnd, takeEnd, splitAtEnd, breakEnd, spanEnd, dropWhileEnd', takeWhileEnd, stripSuffix, stripInfix, stripInfixEnd, dropPrefix, dropSuffix, wordsBy, linesBy, breakOn, breakOnEnd, splitOn, split, chunksOf, notNull, list, unsnoc, cons, snoc, drop1, mconcatMap, enumerate, groupSort, groupSortOn, groupSortBy, nubOrd, nubOrdBy, nubOrdOn, nubOn, groupOn, nubSort, nubSortBy, nubSortOn, maximumOn, minimumOn, disjoint, allSame, anySame, repeatedly, for, firstJust, concatUnzip, concatUnzip3, zipFrom, zipWithFrom, replace, merge, mergeBy,
+    lower, upper, trim, trimStart, trimEnd, word1, line1, escapeHTML, escapeJSON, unescapeHTML, unescapeJSON, dropEnd, takeEnd, splitAtEnd, breakEnd, spanEnd, dropWhileEnd', takeWhileEnd, stripSuffix, stripInfix, stripInfixEnd, dropPrefix, dropSuffix, wordsBy, linesBy, breakOn, breakOnEnd, splitOn, split, chunksOf, headDef, lastDef, notNull, list, unsnoc, cons, snoc, drop1, dropEnd1, mconcatMap, enumerate, groupSort, groupSortOn, groupSortBy, nubOrd, nubOrdBy, nubOrdOn, nubOn, groupOn, nubSort, nubSortBy, nubSortOn, maximumOn, minimumOn, disjoint, allSame, anySame, repeatedly, for, firstJust, concatUnzip, concatUnzip3, zipFrom, zipWithFrom, replace, merge, mergeBy,
     -- * Data.List.NonEmpty.Extra
     -- | Extra functions available in @"Data.List.NonEmpty.Extra"@.
     (|:), (|>), appendl, appendr, maximum1, minimum1, maximumBy1, minimumBy1, maximumOn1, minimumOn1,

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -89,6 +89,12 @@ tests = do
     testGen "allSame []      == True" $ allSame []      == True
     testGen "allSame (1:1:2:undefined) == False" $ allSame (1:1:2:undefined) == False
     testGen "\\xs -> allSame xs == (length (nub xs) <= 1)" $ \xs -> allSame xs == (length (nub xs) <= 1)
+    testGen "headDef 1 []      == 1" $ headDef 1 []      == 1
+    testGen "headDef 1 [2,3,4] == 2" $ headDef 1 [2,3,4] == 2
+    testGen "\\x xs -> headDef x xs == fromMaybe x (listToMaybe xs)" $ \x xs -> headDef x xs == fromMaybe x (listToMaybe xs)
+    testGen "lastDef 1 []      == 1" $ lastDef 1 []      == 1
+    testGen "lastDef 1 [2,3,4] == 4" $ lastDef 1 [2,3,4] == 4
+    testGen "\\x xs -> lastDef x xs == last (x:xs)" $ \x xs -> lastDef x xs == last (x:xs)
     testGen "notNull []  == False" $ notNull []  == False
     testGen "notNull [1] == True" $ notNull [1] == True
     testGen "\\xs -> notNull xs == not (null xs)" $ \xs -> notNull xs == not (null xs)
@@ -183,6 +189,9 @@ tests = do
     testGen "drop1 \"\"         == \"\"" $ drop1 ""         == ""
     testGen "drop1 \"test\"     == \"est\"" $ drop1 "test"     == "est"
     testGen "\\xs -> drop 1 xs == drop1 xs" $ \xs -> drop 1 xs == drop1 xs
+    testGen "dropEnd1 \"\"         == \"\"" $ dropEnd1 ""         == ""
+    testGen "dropEnd1 \"test\"     == \"tes\"" $ dropEnd1 "test"     == "tes"
+    testGen "\\xs -> dropEnd 1 xs == dropEnd1 xs" $ \xs -> dropEnd 1 xs == dropEnd1 xs
     testGen "mconcatMap Sum [1,2,3] == Sum 6" $ mconcatMap Sum [1,2,3] == Sum 6
     testGen "\\f xs -> mconcatMap f xs == concatMap f xs" $ \f xs -> mconcatMap f xs == concatMap f xs
     testGen "breakOn \"::\" \"a::b::c\" == (\"a\", \"::b::c\")" $ breakOn "::" "a::b::c" == ("a", "::b::c")

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -24,6 +24,7 @@ import Data.Function as X
 import Data.IORef.Extra as X
 import Data.List.Extra as X hiding (union, unionBy)
 import Data.List.NonEmpty.Extra as X (NonEmpty(..), (|>), (|:), appendl, appendr, union, unionBy)
+import Data.Maybe as X
 import Data.Monoid as X
 import Data.Tuple.Extra as X
 import Data.Typeable.Extra as X


### PR DESCRIPTION
These new functions, along with the already existing drop1, provide total
replacements for the common cases of head, last, init, and tail, respectively.