### PR TITLE
Slightly optimise nubOrd and add benchmark

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,0 +1,64 @@
+module Main where
+
+import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Data.List.Extra
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "nubOrd"
+    [ bench "Int: Many repeats" $ nf nubOrd intMany
+    , bench "Int: Few repeats " $ nf nubOrd intFew
+    , bench "String: Many repeats" $ nf nubOrd stringMany
+    , bench "String: Few repeats" $ nf nubOrd stringFew
+    ]
+  ]
+
+inputSize :: Int
+inputSize = 100000
+
+intMany :: [Int]
+intMany = take inputSize (cycle [1..1000])
+
+intFew :: [Int]
+intFew = take inputSize (cycle [1..100000])
+
+stringMany :: [String]
+stringMany =
+  let
+    prefix   = replicate 52 (replicate 10 'h')
+    alphabet = fmap pure (['a'..'z'] <> ['A' .. 'Z'])
+    input  = zipWith (<>) prefix alphabet
+  in
+    take inputSize (cycle input)
+
+stringFew :: [String]
+stringFew =
+  let
+    common = [ "the" , "at"  , "there", "some"  , "my"
+             , "of"  , "be"  , "use"  , "her"   , "than"
+             , "and" , "this", "an"   , "would" , "first"
+             , "a"   , "have", "each" , "make"  ,  "water"
+             , "to"  , "from", "which", "like"  ,  "been"
+             , "in"  ,  "or" , "she"  , "him"   ,  "call"
+             , "is"  ,  "one", "do"   , "into"  ,  "who"
+             , "you" ,  "had", "how"  , "time"  ,  "oil"
+             , "that",  "by" , "their", "has"   ,  "its"
+             , "it"  , "word", "if"   , "look"  ,  "now"
+             , "he"  ,  "but", "will" , "two"   ,  "find"
+             , "was" ,  "not", "up"   , "more"  ,  "long"
+             , "for" , "what", "other", "write" ,  "down"
+             , "on"  ,  "all", "about", "go"    ,  "day"
+             , "are" , "were", "out"  , "see"   ,  "did"
+             , "as"  ,  "we" , "many" , "number",  "get"
+             , "with", "when", "then" , "no"    ,  "come"
+             , "his" , "your", "them" , "way"   ,  "made"
+             , "they",  "can", "these", "could" ,  "may"
+             , "I"   , "said", "so"   , "people",  "part"
+             ]
+    addTicks :: Int -> [String] -> [String]
+    addTicks 0 ls = ls
+    addTicks n ls = ls <> fmap (<> "'") ls <> addTicks (n - 1) ls
+
+    input = addTicks 100 common
+  in
+    take inputSize (cycle input)

--- a/benchmark/cabal.project
+++ b/benchmark/cabal.project
@@ -1,0 +1,1 @@
+packages: ../extra.cabal extra-benchmarks.cabal

--- a/benchmark/extra-benchmarks.cabal
+++ b/benchmark/extra-benchmarks.cabal
@@ -1,0 +1,22 @@
+Name:           extra-benchmarks
+Version:        0.1
+License:        BSD3
+License-File:   LICENSE
+author:         Neil Mitchell <ndmitchell@gmail.com>
+maintainer:     Neil Mitchell <ndmitchell@gmail.com>
+copyright:      Neil Mitchell 2014-2019
+Cabal-Version:  >= 1.2
+Build-Type:     Simple
+
+Executable bench
+  Main-Is: Main.hs
+
+  Build-Depends:
+    base >= 2 && < 5,
+    criterion,
+    extra
+
+  Ghc-Options:
+    -O2
+
+  Other-Modules:

--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -772,8 +772,8 @@ insertRB cmp x s = case ins s of
     where
     ins E = T_R E x E
     ins s@(T_B a y b) = case cmp x y of
-        LT -> balance (ins a) y b
-        GT -> balance a y (ins b)
+        LT -> lbalance (ins a) y b
+        GT -> rbalance a y (ins b)
         EQ -> s
     ins s@(T_R a y b) = case cmp x y of
         LT -> T_R (ins a) y b
@@ -793,13 +793,15 @@ memberRB cmp x (T_B a y b) = case cmp x y of
 
 {- balance: first equation is new,
    to make it work with a weaker invariant -}
-balance :: RB a -> a -> RB a -> RB a
-balance (T_R a x b) y (T_R c z d) = T_R (T_B a x b) y (T_B c z d)
-balance (T_R (T_R a x b) y c) z d = T_R (T_B a x b) y (T_B c z d)
-balance (T_R a x (T_R b y c)) z d = T_R (T_B a x b) y (T_B c z d)
-balance a x (T_R b y (T_R c z d)) = T_R (T_B a x b) y (T_B c z d)
-balance a x (T_R (T_R b y c) z d) = T_R (T_B a x b) y (T_B c z d)
-balance a x b = T_B a x b
+lbalance, rbalance :: RB a -> a -> RB a -> RB a
+lbalance (T_R a x b) y (T_R c z d) = T_R (T_B a x b) y (T_B c z d)
+lbalance (T_R (T_R a x b) y c) z d = T_R (T_B a x b) y (T_B c z d)
+lbalance (T_R a x (T_R b y c)) z d = T_R (T_B a x b) y (T_B c z d)
+lbalance a x b = T_B a x b
+rbalance (T_R a x b) y (T_R c z d) = T_R (T_B a x b) y (T_B c z d)
+rbalance a x (T_R b y (T_R c z d)) = T_R (T_B a x b) y (T_B c z d)
+rbalance a x (T_R (T_R b y c) z d) = T_R (T_B a x b) y (T_B c z d)
+rbalance a x b = T_B a x b
 
 
 -- | Like 'zipWith', but keep going to the longest value. The function


### PR DESCRIPTION
I added a slight optimisation to nubOrd (based on the suggestion in Okasaki ex. 3.10a). I also added a benchmark (though I can't claim the inputs are very good or representative). Here are the numbers I got on my machine after this change:

Before:
```
benchmarking nubOrd/Int: Many repeats
time                 9.836 ms   (9.440 ms .. 10.20 ms)
                     0.993 R²   (0.988 R² .. 0.996 R²)
mean                 9.303 ms   (9.147 ms .. 9.481 ms)
std dev              455.6 μs   (366.9 μs .. 565.9 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarking nubOrd/Int: Few repeats 
time                 61.81 ms   (60.09 ms .. 63.63 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 62.06 ms   (61.30 ms .. 63.23 ms)
std dev              1.804 ms   (1.195 ms .. 2.366 ms)

benchmarking nubOrd/String: Many repeats
time                 28.57 ms   (25.79 ms .. 30.84 ms)
                     0.983 R²   (0.974 R² .. 1.000 R²)
mean                 26.29 ms   (25.78 ms .. 27.32 ms)
std dev              1.503 ms   (506.2 μs .. 2.205 ms)
variance introduced by outliers: 21% (moderately inflated)

benchmarking nubOrd/String: Few repeats
time                 13.73 ms   (13.33 ms .. 14.03 ms)
                     0.996 R²   (0.991 R² .. 0.998 R²)
mean                 14.96 ms   (14.60 ms .. 15.43 ms)
std dev              991.7 μs   (800.9 μs .. 1.269 ms)
variance introduced by outliers: 31% (moderately inflated)
```

After:
```
benchmarking nubOrd/Int: Many repeats
time                 8.943 ms   (8.896 ms .. 8.986 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 8.993 ms   (8.968 ms .. 9.024 ms)
std dev              80.14 μs   (64.26 μs .. 98.31 μs)

benchmarking nubOrd/Int: Few repeats 
time                 57.67 ms   (56.56 ms .. 58.47 ms)
                     0.998 R²   (0.993 R² .. 1.000 R²)
mean                 57.97 ms   (57.30 ms .. 59.17 ms)
std dev              1.734 ms   (771.2 μs .. 2.785 ms)

benchmarking nubOrd/String: Many repeats
time                 25.58 ms   (25.00 ms .. 26.07 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 26.36 ms   (25.99 ms .. 26.91 ms)
std dev              1.012 ms   (775.6 μs .. 1.304 ms)

benchmarking nubOrd/String: Few repeats
time                 13.85 ms   (13.70 ms .. 13.96 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 13.91 ms   (13.83 ms .. 14.02 ms)
std dev              232.7 μs   (173.9 μs .. 343.7 μs)
```

More than happy to make any changes you think appropriate.
