### PR TITLE
Fix the exports of `Data.Foldable.Extra` and resolve #41

### DIFF
--- a/src/Data/Foldable/Extra.hs
+++ b/src/Data/Foldable/Extra.hs
@@ -1,5 +1,8 @@
 module Data.Foldable.Extra
-    ( sumOn'
+    ( module Data.Foldable
+    , sum'
+    , product'
+    , sumOn'
     , productOn'
     ) where
 

--- a/src/Data/Foldable/Extra.hs
+++ b/src/Data/Foldable/Extra.hs
@@ -4,9 +4,16 @@ module Data.Foldable.Extra
     , product'
     , sumOn'
     , productOn'
+    , anyM
+    , allM
+    , orM
+    , andM
+    , findM
+    , firstJustM
     ) where
 
 import Data.Foldable
+import qualified Control.Monad.Extra as MX
 
 -- | A generalization of `Data.List.Extra.sum'` to Foldable instances.
 sum' :: (Foldable f, Num a) => f a -> a
@@ -23,3 +30,27 @@ sumOn' f = foldl' (\acc x -> acc + f x) 0
 -- | A generalization of `Data.List.Extra.productOn'` to Foldable instances.
 productOn' :: (Foldable f, Num b) => (a -> b) -> f a -> b
 productOn' f = foldl' (\acc x -> acc * f x) 1
+
+-- | A generalization of `Control.Monad.Extra.anyM` to Foldable instances. Retains the short-circuiting behaviour.
+anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+anyM p = foldr ((MX.||^) . p) (pure False)
+
+-- | A generalization of `Control.Monad.Extra.allM` to Foldable instances. Retains the short-circuiting behaviour.
+allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+allM p = foldr ((MX.&&^) . p) (pure True)
+
+-- | A generalization of `Control.Monad.Extra.orM` to Foldable instances. Retains the short-circuiting behaviour.
+orM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
+orM = anyM id
+
+-- | A generalization of `Control.Monad.Extra.andM` to Foldable instances. Retains the short-circuiting behaviour.
+andM :: (Foldable f, Monad m) => f (m Bool) -> m Bool
+andM = allM id
+
+-- | A generalization of `Control.Monad.Extra.findM` to Foldable instances.
+findM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m (Maybe a)
+findM p = foldr (\x -> MX.ifM (p x) (pure $ Just x)) (pure Nothing)
+
+-- | A generalization of `Control.Monad.Extra.firstJustM` to Foldable instances.
+firstJustM :: (Foldable f, Monad m) => (a -> m (Maybe b)) -> f a -> m (Maybe b)
+firstJustM p = MX.firstJustM p . toList


### PR DESCRIPTION
Just noticed that I forgot to export the `Data.Foldable` module on top of the extra functions, as per the style of this library. Also, I copied the code from `Control.Monad.Extra` for the functions mentioned in #41 since I think this is not a better place for them.