### PR TITLE
Hide conflicting strict functions from base-4.15.

### DIFF
--- a/src/System/IO/Extra.hs
+++ b/src/System/IO/Extra.hs
@@ -21,7 +21,7 @@ module System.IO.Extra(
     fileEq,
     ) where
 
-import System.IO
+import System.IO hiding (hGetContents', readFile')
 import Control.Concurrent.Extra
 import Control.Monad.Extra
 import Control.Exception.Extra as E


### PR DESCRIPTION
This package fails to build under GHC 9 because the strict functions added to `System.IO` in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1918 conflict with those defined and then used in `System.IO.Extra`, producing ambiguous occurrence errors.  The simple solution is just to hide the functions in question in the import.

In the long run, these Extra functions can probably be deprecated and ultimately removed now that they duplicate functionality available in `base`, although I guess it's possible their behavior isn't exactly the same.  That would of course be a breaking change.