### PR TITLE
takeEnd, dropEnd, splitAtEnd: return immediately if i<=0

### DIFF
--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -199,7 +199,9 @@ enumerate = [minBound..maxBound]
 -- > \i xs -> takeEnd i xs `isSuffixOf` xs
 -- > \i xs -> length (takeEnd i xs) == min (max 0 i) (length xs)
 takeEnd :: Int -> [a] -> [a]
-takeEnd i xs = f xs (drop i xs)
+takeEnd i xs
+    | i <= 0 = []
+    | otherwise = f xs (drop i xs)
     where f (x:xs) (y:ys) = f xs ys
           f xs _ = xs
 
@@ -212,7 +214,9 @@ takeEnd i xs = f xs (drop i xs)
 -- > \i xs -> length (dropEnd i xs) == max 0 (length xs - max 0 i)
 -- > \i -> take 3 (dropEnd 5 [i..]) == take 3 [i..]
 dropEnd :: Int -> [a] -> [a]
-dropEnd i xs = f xs (drop i xs)
+dropEnd i xs
+    | i <= 0 = xs
+    | otherwise = f xs (drop i xs)
     where f (x:xs) (y:ys) = x : f xs ys
           f _ _ = []
 
@@ -225,7 +229,9 @@ dropEnd i xs = f xs (drop i xs)
 -- > \i xs -> uncurry (++) (splitAt i xs) == xs
 -- > \i xs -> splitAtEnd i xs == (dropEnd i xs, takeEnd i xs)
 splitAtEnd :: Int -> [a] -> ([a], [a])
-splitAtEnd i xs = f xs (drop i xs)
+splitAtEnd i xs
+    | i <= 0 = (xs, [])
+    | otherwise = f xs (drop i xs)
     where f (x:xs) (y:ys) = first (x:) $ f xs ys
           f xs _ = ([], xs)
 


### PR DESCRIPTION
Currently they take linear time even if `i <= 0`.