### PR TITLE
Add assertIO function

### DIFF
--- a/src/Control/Exception/Extra.hs
+++ b/src/Control/Exception/Extra.hs
@@ -13,7 +13,7 @@ module Control.Exception.Extra(
     retry, retryBool,
     errorWithoutStackTrace,
     showException, stringException,
-    errorIO,
+    errorIO, assertIO,
     -- * Exception catching/ignoring
     ignore,
     catch_, handle_, try_,
@@ -85,6 +85,14 @@ withFrozenCallStack :: a -> a
 withFrozenCallStack = id
 #endif
 
+-- | An 'IO' action that when evaluated calls 'assert' in the 'IO' monad, which throws an 'AssertionFailed' exception if the argument is 'False'.
+--   With optimizations enabled (and @-fgnore-asserts@) this function ignores its argument and does nothing.
+--
+-- > catch (assertIO True  >> pure 1) (\(x :: AssertionFailed) -> pure 2) == pure 1
+-- > catch (assertIO False >> pure 1) (\(x :: AssertionFailed) -> pure 2) == pure 2
+-- > seq (assertIO False) (print 1) == print 1
+assertIO :: Partial => Bool -> IO ()
+assertIO x = withFrozenCallStack $ evaluate $ assert x ()
 
 -- | Retry an operation at most /n/ times (/n/ must be positive).
 --   If the operation fails the /n/th time it will throw that final exception.

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -26,6 +26,9 @@ tests = do
     testGen "ignore (fail \"die\") == pure ()" $ ignore (fail "die") == pure ()
     testGen "catch (errorIO \"Hello\") (\\(ErrorCall x) -> pure x) == pure \"Hello\"" $ catch (errorIO "Hello") (\(ErrorCall x) -> pure x) == pure "Hello"
     testGen "seq (errorIO \"foo\") (print 1) == print 1" $ seq (errorIO "foo") (print 1) == print 1
+    testGen "catch (assertIO True  >> pure 1) (\\(x :: AssertionFailed) -> pure 2) == pure 1" $ catch (assertIO True  >> pure 1) (\(x :: AssertionFailed) -> pure 2) == pure 1
+    testGen "catch (assertIO False >> pure 1) (\\(x :: AssertionFailed) -> pure 2) == pure 2" $ catch (assertIO False >> pure 1) (\(x :: AssertionFailed) -> pure 2) == pure 2
+    testGen "seq (assertIO False) (print 1) == print 1" $ seq (assertIO False) (print 1) == print 1
     testGen "retry 1 (print \"x\")  == print \"x\"" $ retry 1 (print "x")  == print "x"
     testGen "retry 3 (fail \"die\") == fail \"die\"" $ retry 3 (fail "die") == fail "die"
     testGen "whenJust Nothing  print == pure ()" $ whenJust Nothing  print == pure ()


### PR DESCRIPTION
This is a function similar to `errorIO` that allows using assertions as actions:
```Haskell
main = do
  x <- getLine -- a complex computation
  assertIO (length x > 3)
```
It seems to optimize away like the original `assert`, at least for the simple program above. I'm not sure why `errorIO` has a `NOINLINE` but I left it out here because it would remove the optimization property.