### PR TITLE
Point out more general `whenJust` in base

### DIFF
--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -30,6 +30,7 @@ import Prelude
 -- General utilities
 
 -- | Perform some operation on 'Just', given the field inside the 'Just'.
+--   This is a specialized 'Data.Foldable.for_'.
 --
 -- > whenJust Nothing  print == pure ()
 -- > whenJust (Just 1) print == print 1


### PR DESCRIPTION
I just noticed today that a `whenJust` is available in base. I think this could be useful information, since it wasn't obvious to me at all, I always compared it to `foldMapM` from Relude instead.