### PR TITLE
Add replaceRight and replaceLeft functions

### DIFF
--- a/src/Data/Either/Extra.hs
+++ b/src/Data/Either/Extra.hs
@@ -13,6 +13,7 @@ module Data.Either.Extra(
     fromLeft', fromRight',
     eitherToMaybe, maybeToEither,
     mapLeft, mapRight,
+    replaceLeft, replaceRight,
     ) where
 
 import Data.Either

--- a/src/Data/Either/Extra.hs
+++ b/src/Data/Either/Extra.hs
@@ -110,7 +110,7 @@ mapRight = fmap
 -- > replaceLeft "One" (Left 1) == Left "One"
 -- > replaceLeft "One" (Right 1) == Right 1
 replaceLeft :: c -> Either a b -> Either c b
-replaceLeft l = mapLeft $ const l
+replaceLeft = mapLeft . const
 
 -- | The `replaceRight` function takes a value and an Either value and
 -- replaces the Either value if the Either value takes the form @'Right' _@.
@@ -118,4 +118,4 @@ replaceLeft l = mapLeft $ const l
 -- > replaceRight "One" (Left 1) == Left 1
 -- > replaceRight "One" (Right 1) == Right "One"
 replaceRight :: c -> Either a b -> Either a c
-replaceRight r = mapRight $ const r
+replaceRight = mapRight . const

--- a/src/Data/Either/Extra.hs
+++ b/src/Data/Either/Extra.hs
@@ -102,3 +102,19 @@ mapLeft f = either (Left . f) Right
 -- > mapRight show (Right True) == Right "True"
 mapRight :: (b -> c) -> Either a b -> Either a c
 mapRight = fmap
+
+-- | The `replaceLeft` function takes a value and an Either value and
+-- replaces the Either value if the Either value takes the form @'Left' _@.
+--
+-- > replaceLeft "One" (Left 1) == Left "One"
+-- > replaceLeft "One" (Right 1) == Right 1
+replaceLeft :: c -> Either a b -> Either c b
+replaceLeft l = mapLeft $ const l
+
+-- | The `replaceRight` function takes a value and an Either value and
+-- replaces the Either value if the Either value takes the form @'Right' _@.
+--
+-- > replaceRight "One" (Left 1) == Left 1
+-- > replaceRight "One" (Right 1) == Right "One"
+replaceRight :: c -> Either a b -> Either a c
+replaceRight r = mapRight $ const r

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -81,6 +81,10 @@ tests = do
     testGen "mapLeft show (Right True) == Right True" $ mapLeft show (Right True) == Right True
     testGen "mapRight show (Left 1) == Left 1" $ mapRight show (Left 1) == Left 1
     testGen "mapRight show (Right True) == Right \"True\"" $ mapRight show (Right True) == Right "True"
+    testGen "replaceLeft \"One\" (Left 1) == Left \"One\"" $ replaceLeft "One" (Left 1) == Left "One"
+    testGen "replaceLeft \"One\" (Right 1) == Right 1" $ replaceLeft "One" (Right 1) == Right 1
+    testGen "replaceRight \"One\" (Left 1) == Left 1" $ replaceRight "One" (Left 1) == Left 1
+    testGen "replaceRight \"One\" (Right 1) == Right \"One\"" $ replaceRight "One" (Right 1) == Right "One"
     testGen "\\xs -> repeatedly (splitAt 3) xs  == chunksOf 3 xs" $ \xs -> repeatedly (splitAt 3) xs  == chunksOf 3 xs
     testGen "\\xs -> repeatedly word1 (trim xs) == words xs" $ \xs -> repeatedly word1 (trim xs) == words xs
     testGen "\\xs -> repeatedly line1 xs == lines xs" $ \xs -> repeatedly line1 xs == lines xs


### PR DESCRIPTION
- [x] By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

- [x] If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.

I find the `replaceLeft` function useful for "translating" error handling from a library's domain to my own domain (to encapsulate the library's domain).

Example (pseudo code):
* External library:
```haskell
gitInfo :: Either GitHashException GitInfo
```
* Encapsulation of `GitHashException`:
```haskell
doSomethingSpecial :: Either MyAppError MyResultType
doSomethingSpecial = replaceLeft SpecialError res
  where 
     res = doSomeThingSpecialWith <$> gitInfo
```