### PR TITLE
Future-proof against addition of Data.List.!?

### DIFF
--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TupleSections, ConstraintKinds #-}
+{-# LANGUAGE CPP, TupleSections, ConstraintKinds #-}
 
 -- | This module extends "Data.List" with extra functions of a similar nature.
 --   The package also exports the existing "Data.List" functions.
@@ -156,6 +156,7 @@ lastDef :: a -> [a] -> a
 lastDef d xs = foldl (\_ x -> x) d xs -- I know this looks weird, but apparently this is the fastest way to do this: https://hackage.haskell.org/package/base-4.12.0.0/docs/src/GHC.List.html#last
 {-# INLINE lastDef #-}
 
+#if !MIN_VERSION_base(4,19,0)
 -- | A total variant of the list index function `(!!)`.
 --
 -- > [2,3,4] !? 1    == Just 3
@@ -169,6 +170,7 @@ xs !? n
                                    0 -> Just x
                                    _ -> r (k-1)) (const Nothing) xs n
 {-# INLINABLE (!?) #-}
+#endif
 
 -- | A composition of 'not' and 'null'.
 --


### PR DESCRIPTION
`base-4.19` (and GHC 9.8) will export `Data.List.!?`, which will clash with `Data.List.Extra.!?` in 
https://github.com/ndmitchell/extra/blob/374ebbc12cb4b9580394556c5e5c7b1bf250d817/src/Data/List/Extra.hs#L164-L170

This PR wraps the definition of `Data.List.Extra.!?` in CPP to prevent the name clash.

See https://github.com/haskell/core-libraries-committee/issues/110#issuecomment-1359037078 for CLC discussion of the change.