### PR TITLE
fix ghc-9.7 compilation errors

### DIFF
--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -38,7 +38,7 @@ module Data.List.Extra(
     ) where
 
 import Partial
-import Data.List
+import Data.List hiding (unsnoc, (!?))
 import Data.Maybe
 import Data.Function
 import Data.Char
@@ -288,7 +288,7 @@ zipWithFrom f a = zipWith f [a..]
 --
 -- > concatUnzip [("a","AB"),("bc","C")] == ("abc","ABC")
 concatUnzip :: [([a], [b])] -> ([a], [b])
-concatUnzip = (concat *** concat) . unzip
+concatUnzip = (concat *** concat) . Prelude.unzip
 
 -- | A merging of 'unzip3' and 'concat'.
 --


### PR DESCRIPTION
i happened to try building with ghc built from head today (ghc.9.7.20230617) and found it failed with some ambiguities. this seems to fix it. tested with `cabal new-build all`