### PR TITLE
Add the guarded function (lifting into Alternative via predicate)

### DIFF
--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -11,7 +11,7 @@ module Control.Monad.Extra(
     whenMaybe, whenMaybeM,
     unit,
     maybeM, fromMaybeM, eitherM,
-    guarded,
+    guarded, guardedA,
     -- * Loops
     loop, loopM, whileM, whileJustM, untilJustM,
     -- * Lists
@@ -97,6 +97,15 @@ eitherM l r x = either l r =<< x
 -- > guarded (not.null) "My Name" == Just "My Name"
 guarded :: Alternative m => (a -> Bool) -> a -> m a
 guarded pred x = if pred x then pure x else empty
+
+-- | A variant of `guarded` using 'Functor'-wrapped values.
+--
+-- > guardedA (return . even) 42    == Just [42]
+-- > guardedA (return . odd) 42     == Just []
+-- > guardedA (const Nothing) 42    == (Nothing :: Maybe [Int])
+guardedA :: (Functor f, Alternative m) => (a -> f Bool) -> a -> f (m a)
+guardedA pred x = fmap inner (pred x)
+    where inner b = if b then pure x else empty
 
 -- | A variant of 'foldM' that has no base case, and thus may only be applied to non-empty lists.
 --

--- a/src/Control/Monad/Extra.hs
+++ b/src/Control/Monad/Extra.hs
@@ -11,6 +11,7 @@ module Control.Monad.Extra(
     whenMaybe, whenMaybeM,
     unit,
     maybeM, fromMaybeM, eitherM,
+    guarded,
     -- * Loops
     loop, loopM, whileM, whileJustM, untilJustM,
     -- * Lists
@@ -87,6 +88,15 @@ fromMaybeM n x = maybeM n pure x
 -- | Monadic generalisation of 'either'.
 eitherM :: Monad m => (a -> m c) -> (b -> m c) -> m (Either a b) -> m c
 eitherM l r x = either l r =<< x
+
+-- | Either lifts a value into an alternative context or gives a
+--   minimal value depending on a predicate. Works with 'Alternative's.
+--
+-- > guarded even 2 == [2]
+-- > guarded odd 2 == Nothing
+-- > guarded (not.null) "My Name" == Just "My Name"
+guarded :: Alternative m => (a -> Bool) -> a -> m a
+guarded pred x = if pred x then pure x else empty
 
 -- | A variant of 'foldM' that has no base case, and thus may only be applied to non-empty lists.
 --

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -14,7 +14,7 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     Partial, retry, retryBool, errorWithoutStackTrace, showException, stringException, errorIO, assertIO, ignore, catch_, handle_, try_, catchJust_, handleJust_, tryJust_, catchBool, handleBool, tryBool,
     -- * Control.Monad.Extra
     -- | Extra functions available in @"Control.Monad.Extra"@.
-    whenJust, whenJustM, pureIf, whenMaybe, whenMaybeM, unit, maybeM, fromMaybeM, eitherM, loop, loopM, whileM, whileJustM, untilJustM, partitionM, concatMapM, concatForM, mconcatMapM, mapMaybeM, findM, firstJustM, fold1M, fold1M_, whenM, unlessM, ifM, notM, (||^), (&&^), orM, andM, anyM, allM,
+    whenJust, whenJustM, pureIf, whenMaybe, whenMaybeM, unit, maybeM, fromMaybeM, eitherM, guarded, guardedA, loop, loopM, whileM, whileJustM, untilJustM, partitionM, concatMapM, concatForM, mconcatMapM, mapMaybeM, findM, firstJustM, fold1M, fold1M_, whenM, unlessM, ifM, notM, (||^), (&&^), orM, andM, anyM, allM,
     -- * Data.Either.Extra
     -- | Extra functions available in @"Data.Either.Extra"@.
     fromLeft, fromRight, fromEither, fromLeft', fromRight', eitherToMaybe, maybeToEither, mapLeft, mapRight,

--- a/test/TestGen.hs
+++ b/test/TestGen.hs
@@ -37,6 +37,12 @@ tests = do
     testGen "whenMaybe True  (print 1) == fmap Just (print 1)" $ whenMaybe True  (print 1) == fmap Just (print 1)
     testGen "whenMaybe False (print 1) == pure Nothing" $ whenMaybe False (print 1) == pure Nothing
     testGen "\\(x :: Maybe ()) -> unit x == x" $ \(x :: Maybe ()) -> unit x == x
+    testGen "guarded even 2 == [2]" $ guarded even 2 == [2]
+    testGen "guarded odd 2 == Nothing" $ guarded odd 2 == Nothing
+    testGen "guarded (not.null) \"My Name\" == Just \"My Name\"" $ guarded (not.null) "My Name" == Just "My Name"
+    testGen "guardedA (return . even) 42    == Just [42]" $ guardedA (return . even) 42    == Just [42]
+    testGen "guardedA (return . odd) 42     == Just []" $ guardedA (return . odd) 42     == Just []
+    testGen "guardedA (const Nothing) 42    == (Nothing :: Maybe [Int])" $ guardedA (const Nothing) 42    == (Nothing :: Maybe [Int])
     testGen "fold1M (\\x y -> Just x) [] == undefined" $ erroneous $ fold1M (\x y -> Just x) []
     testGen "fold1M (\\x y -> Just $ x + y) [1, 2, 3] == Just 6" $ fold1M (\x y -> Just $ x + y) [1, 2, 3] == Just 6
     testGen "partitionM (Just . even) [1,2,3] == Just ([2], [1,3])" $ partitionM (Just . even) [1,2,3] == Just ([2], [1,3])


### PR DESCRIPTION
I'd like to add the `guarded` function, which I often need. It is well known by [relude](https://hackage.haskell.org/package/relude/docs/Relude-Bool-Guard.html#v:guarded) or [Protolude](https://hackage.haskell.org/package/protolude/docs/Protolude.html#v:guarded).

I was able to run the test suite and I added documentation including code examples, which should lead to auto-generated tests, but I was unable to run `Generate.hs` in my GHC 9.4.7 environment. Any hints?

## TODO

- [x] Implement the function
- [x] Write haddock
- [x] Include testable code in haddock
- [x] Check with @ndmitchell if it's the correct namespace
- [x] Maybe also add [`guardedA`](https://hackage.haskell.org/package/protolude/docs/Protolude.html#v:guardedA)?
- [x] Auto-generate tests