### PR TITLE
Add failLeft

### DIFF
--- a/src/Data/Either/Extra.hs
+++ b/src/Data/Either/Extra.hs
@@ -102,3 +102,7 @@ mapLeft f = either (Left . f) Right
 -- > mapRight show (Right True) == Right "True"
 mapRight :: (b -> c) -> Either a b -> Either a c
 mapRight = fmap
+
+-- | Lift an 'Either String' to a 'MonadFail'
+failLeft :: MonadFail m => Either String a -> m a
+failLeft = either fail pure


### PR DESCRIPTION
It's a function I rewrite quite often and I'm surprised it doesn't exist already.

Is there a need to add CPP to account for the evolution of `MonadFail`?