### PR TITLE
Hide non-working clock dependency from the javascript back end

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Changelog for Extra (* = breaking change)
 
+1.9, released 2026-05-23
+    Remove the offsetTime function and the dependency on the clock
+    package, which is troublesome for the javascript back end.
 1.8.1, released 2025-11-23
     #118, future proof for GHC 9.16 gaining nubOrd and nubOrdBy
     Test with GHC 9.12

--- a/extra.cabal
+++ b/extra.cabal
@@ -1,12 +1,12 @@
 cabal-version:      1.18
 build-type:         Simple
 name:               extra
-version:            1.8.1
+version:            1.9
 license:            BSD3
 license-file:       LICENSE
 category:           Development
 author:             Neil Mitchell <ndmitchell@gmail.com>
-maintainer:         Neil Mitchell <ndmitchell@gmail.com>
+maintainer:         Neil Mitchell <ndmitchell@gmail.com>, David Fox <ddssff@gmail.com>
 copyright:          Neil Mitchell 2014-2025
 synopsis:           Extra functions I use.
 description:
@@ -35,8 +35,9 @@ library
         directory,
         filepath,
         process,
-        clock >= 0.7,
         time
+    if !impl(ghcjs) && !arch(javascript)
+        build-depends: clock >= 0.7
     if !os(windows)
         build-depends: unix
 

--- a/extra.cabal
+++ b/extra.cabal
@@ -6,7 +6,7 @@ license:            BSD3
 license-file:       LICENSE
 category:           Development
 author:             Neil Mitchell <ndmitchell@gmail.com>
-maintainer:         Neil Mitchell <ndmitchell@gmail.com>, David Fox <ddssff@gmail.com>
+maintainer:         Neil Mitchell <ndmitchell@gmail.com>
 copyright:          Neil Mitchell 2014-2025
 synopsis:           Extra functions I use.
 description:
@@ -36,7 +36,7 @@ library
         filepath,
         process,
         time
-    if !impl(ghcjs) && !arch(javascript)
+    if !arch(javascript)
         build-depends: clock >= 0.7
     if !os(windows)
         build-depends: unix

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -56,7 +56,7 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     -- * System.Time.Extra
     -- | Extra functions available in @"System.Time.Extra"@.
     Seconds, sleep, timeout, showDuration
-#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+#if !defined(javascript_HOST_ARCH)
     , offsetTime, offsetTimeIncrease, duration
 #endif
     ) where

--- a/src/Extra.hs
+++ b/src/Extra.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- GENERATED CODE - DO NOT MODIFY
 -- See Generate.hs for details of how to generate
 
@@ -53,7 +55,10 @@ module Extra {-# DEPRECATED "This module is provided as documentation of all new
     system_, systemOutput, systemOutput_,
     -- * System.Time.Extra
     -- | Extra functions available in @"System.Time.Extra"@.
-    Seconds, sleep, timeout, showDuration, offsetTime, offsetTimeIncrease, duration,
+    Seconds, sleep, timeout, showDuration
+#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+    , offsetTime, offsetTimeIncrease, duration
+#endif
     ) where
 
 import Control.Concurrent.Extra

--- a/src/System/Time/Extra.hs
+++ b/src/System/Time/Extra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP, DeriveDataTypeable #-}
 
 -- | Extra functions for working with times. Unlike the other modules in this package, there is no
 --   corresponding @System.Time@ module. This module enhances the functionality
@@ -8,12 +8,16 @@
 module System.Time.Extra(
     Seconds,
     sleep, timeout,
-    showDuration,
-    offsetTime, offsetTimeIncrease, duration
+    showDuration
+#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+    , offsetTime, offsetTimeIncrease, duration
+#endif
     ) where
 
 import Control.Concurrent
+#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
 import System.Clock
+#endif
 import Numeric.Extra
 import Control.Monad.IO.Class
 import Control.Monad.Extra
@@ -87,7 +91,7 @@ showDuration x
         f x m s = show ms ++ m ++ ['0' | ss < 10] ++ show ss ++ s
             where (ms,ss) = round x `divMod` 60
 
-
+#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
 -- | Call once to start, then call repeatedly to get the elapsed time since the first call.
 --   The time is guaranteed to be monotonic. This function is robust to system time changes.
 --
@@ -115,3 +119,4 @@ duration act = do
     res <- act
     time <- liftIO time
     pure (time, res)
+#endif

--- a/src/System/Time/Extra.hs
+++ b/src/System/Time/Extra.hs
@@ -9,13 +9,13 @@ module System.Time.Extra(
     Seconds,
     sleep, timeout,
     showDuration
-#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+#if !defined(javascript_HOST_ARCH)
     , offsetTime, offsetTimeIncrease, duration
 #endif
     ) where
 
 import Control.Concurrent
-#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+#if !defined(javascript_HOST_ARCH)
 import System.Clock
 #endif
 import Numeric.Extra
@@ -91,7 +91,7 @@ showDuration x
         f x m s = show ms ++ m ++ ['0' | ss < 10] ++ show ss ++ s
             where (ms,ss) = round x `divMod` 60
 
-#if !__GHCJS__ && !defined(javascript_HOST_ARCH)
+#if !defined(javascript_HOST_ARCH)
 -- | Call once to start, then call repeatedly to get the elapsed time since the first call.
 --   The time is guaranteed to be monotonic. This function is robust to system time changes.
 --


### PR DESCRIPTION
Sorry about bumping the version number, I can back that out.  The clock package is available for the javascript back end, but it does not work, so this patch omits the dependency and the functions that use it.   At some point this can be worked out correctly, but this clears a path forward.  Sorry for using CPP, I don't think there's any alternative.